### PR TITLE
Offical update source

### DIFF
--- a/man/update-sources.md
+++ b/man/update-sources.md
@@ -13,7 +13,7 @@
 ## 官方更新源
 
 ```
-https://dev.azure.com/blessing-skin/51010f6d-9f99-40f1-a262-0a67f788df32/_apis/git/repositories/a9ff8df7-6dc3-4ff8-bb22-4871d3a43936/Items?path=%2Fupdate_2.json
+https://dev.azure.com/blessing-skin/51010f6d-9f99-40f1-a262-0a67f788df32/_apis/git/repositories/a9ff8df7-6dc3-4ff8-bb22-4871d3a43936/Items?path=%2Fupdate_preview.json
 ```
 
 官方更新源位于 Azure DevOps。你不需要手动添加官方更新源，默认情况下即是从官方更新源获取更新。


### PR DESCRIPTION
官方更新源的链接已经不可用，应该修改为新的 update_preview.json 了